### PR TITLE
Accomodate Android 13

### DIFF
--- a/android/src/main/java/com/example/sunmi_scanner/SunmiScannerPlugin.java
+++ b/android/src/main/java/com/example/sunmi_scanner/SunmiScannerPlugin.java
@@ -100,10 +100,11 @@ public class SunmiScannerPlugin implements FlutterPlugin, MethodCallHandler, Str
     @Override
     public void onListen(Object arguments, EventSink events) {
         scannerServiceReceiver = createScannerServiceReceiver(events);
-        context.registerReceiver(
-                scannerServiceReceiver,
-                new IntentFilter("com.sunmi.scanner.ACTION_DATA_CODE_RECEIVED")
-        );
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+            context.registerReceiver(scannerServiceReceiver, new IntentFilter("com.sunmi.scanner.ACTION_DATA_CODE_RECEIVED"), Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            context.registerReceiver(scannerServiceReceiver, new IntentFilter("com.sunmi.scanner.ACTION_DATA_CODE_RECEIVED"));
+        }
     }
 
     /**


### PR DESCRIPTION
## Accomodate Android 13+ (SDK 33)
This pull request updates the way the scanner broadcast receiver is registered to improve compatibility with newer Android versions. The main change is a conditional check for Android version, ensuring the receiver is registered with the correct export flag when running on Android 13 (TIRAMISU) or later.

Android compatibility improvement:
* Updated `onListen` in `SunmiScannerPlugin.java` to register the scanner broadcast receiver with `Context.RECEIVER_NOT_EXPORTED` on Android 13+ for enhanced security and compliance with platform requirements.

https://developer.android.com/reference/android/content/Context#RECEIVER_NOT_EXPORTED

## Issue ticket number and link
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
Yes.
- [x] If it is a core feature, I have added thorough tests.
No.
- [x] Do we need to implement analytics?
No.
- [x] Will this be part of a product update? If yes, please write one phrase about this update.
Yes: Android 13 Support.
